### PR TITLE
fix `_kill_if_running` for root processes (#321)

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -283,7 +283,7 @@ _dfuhelper() {
 }
 
 _kill_if_running() {
-    if (pgrep -u root -xf "$1" &> /dev/null > /dev/null); then
+    if (pgrep -u root -x "$1" &> /dev/null > /dev/null); then
         # yes, it's running as root. kill it
         sudo killall $1
     else


### PR DESCRIPTION
`-f` means match full command line, so it never matched for iproxy, causing errors when trying to kill the root process as normal user